### PR TITLE
[UI] 프로필 UI 변경 및 버그 해소

### DIFF
--- a/42manito/src/components/Profile/Categories.tsx
+++ b/42manito/src/components/Profile/Categories.tsx
@@ -9,13 +9,13 @@ export default function ProfileCategories({ categories }: props) {
   return (
     <div className="flex flex-col justify-start items-center  w-[50vw] overflow-y-auto mb-10">
       <span className="text-3xl font-bold text-slate-800 dark:text-slate-200">
-        멘토링 분야
+        카테고리
       </span>
       <div className="flex flex-wrap justify-center w-full my-3">
         {categories.length > 0 &&
           categories.map((aTag) => (
             <h6
-              className="m-2 p-[0.5vw] rounded-md bg-rose-200 dark:bg-rose-700 "
+              className="whitespace-nowrap m-2 text-sm rounded-full px-[0.5em] py-[0.2em] bg-rose-300 dark:bg-rose-800"
               key={aTag.id}
             >
               {aTag.name}

--- a/42manito/src/components/Profile/CategoryCard.tsx
+++ b/42manito/src/components/Profile/CategoryCard.tsx
@@ -18,7 +18,7 @@ const CategoryCard = ({ category, active, onClick, children }: props) => {
     <div className="flex flex-row mr-3">
       <h6
         onClick={handleClick}
-        className={`whitespace-nowrap m-2 p-[0.5vw] rounded-md focus:outline-none focus:ring focus:ring-rose-300 
+        className={`whitespace-nowrap m-2 text-sm rounded-full px-[0.5em] py-[0.2em] focus:outline-none focus:ring focus:ring-rose-300 
         ${
           isActive
             ? "bg-rose-300 dark:bg-rose-500 ring ring-rose-800"

--- a/42manito/src/components/Profile/Description.tsx
+++ b/42manito/src/components/Profile/Description.tsx
@@ -28,7 +28,11 @@ function DescriptionComponent({ description }: props) {
 
   const linkedDescription = linkifyReact(description);
 
-  return <div className="w-full whitespace-pre-wrap">{linkedDescription}</div>;
+  return (
+    <div className="whitespace-pre-wrap w-[50vw] break-words">
+      {linkedDescription}
+    </div>
+  );
 }
 
 export default DescriptionComponent;

--- a/42manito/src/components/Profile/Description.tsx
+++ b/42manito/src/components/Profile/Description.tsx
@@ -29,7 +29,12 @@ function DescriptionComponent({ description }: props) {
   const linkedDescription = linkifyReact(description);
 
   return (
-    <div className="whitespace-pre-wrap w-[50vw] break-words">
+    <div
+      className="whitespace-pre-wrap w-[100%] break-words
+      px-6 py-4 rounded-2xl
+      bg-gray-100 dark:bg-gray-800
+      shadow-sm"
+    >
       {linkedDescription}
     </div>
   );

--- a/42manito/src/components/Profile/Hashtag.tsx
+++ b/42manito/src/components/Profile/Hashtag.tsx
@@ -7,6 +7,11 @@ interface props {
 }
 
 export default function ProfileHashtag({ hashtag }: props) {
+  const router = useRouter();
+  const handleClick = (hashtag: string) => {
+    router.push(`/Search/${hashtag}`);
+  };
+
   return (
     <div className="flex flex-col justify-start items-center w-[50vw] overflow-y-auto mb-10">
       <span className="text-3xl font-bold text-slate-800 dark:text-slate-200">
@@ -18,6 +23,7 @@ export default function ProfileHashtag({ hashtag }: props) {
             <button
               className="whitespace-nowrap m-2 text-sm rounded-full px-[0.5em] py-[0.2em] bg-sky-300 dark:bg-sky-800"
               key={aTag.id}
+              onClick={() => handleClick(aTag.name)}
             >
               {aTag.name}
             </button>

--- a/42manito/src/components/Profile/Hashtag.tsx
+++ b/42manito/src/components/Profile/Hashtag.tsx
@@ -1,5 +1,6 @@
 import { HashtagResponseDto } from "@/Types/Hashtags/HashtagResponse.dto";
 import React from "react";
+import { useRouter } from "next/router";
 
 interface props {
   hashtag: HashtagResponseDto[];
@@ -14,12 +15,12 @@ export default function ProfileHashtag({ hashtag }: props) {
       <div className="flex flex-wrap justify-center w-full my-3">
         {hashtag.length > 0 &&
           hashtag.map((aTag) => (
-            <h6
-              className="m-2 p-[0.5vw] rounded-md bg-sky-200 dark:bg-sky-700 "
+            <button
+              className="whitespace-nowrap m-2 text-sm rounded-full px-[0.5em] py-[0.2em] bg-sky-300 dark:bg-sky-800"
               key={aTag.id}
             >
               {aTag.name}
-            </h6>
+            </button>
           ))}
       </div>
     </div>

--- a/42manito/src/components/Profile/HashtagCard.tsx
+++ b/42manito/src/components/Profile/HashtagCard.tsx
@@ -8,7 +8,7 @@ interface props {
 const HashtagCard = ({ hashtag, children }: props) => {
   return (
     <div className="flex flex-row mr-3">
-      <h6 className="whitespace-nowrap m-2 p-[0.5vw] rounded-md bg-sky-200 dark:bg-sky-700 ">
+      <h6 className="whitespace-nowrap m-2 px-[0.5em] py-[0.2em] rounded-full bg-sky-200 dark:bg-sky-700 ">
         {hashtag}
       </h6>
       {children && children}

--- a/42manito/src/components/Profile/Toggle.tsx
+++ b/42manito/src/components/Profile/Toggle.tsx
@@ -31,8 +31,8 @@ export default function ManitoToggle() {
   }, [userDate, userLoading]);
 
   return (
-    <div className="items-center justify-center flex flex-row">
-      <div className="text-xl font-bold mr-3">프로필 공개하기</div>
+    <div className="items-center justify-center flex flex-row mb-5">
+      <div className="text-lg font-bold mr-3 mb-0.5">프로필 공개하기</div>
       <label className="relative inline-flex items-center cursor-pointer">
         <input
           type="checkbox"

--- a/42manito/src/components/Profile/UserProfile.tsx
+++ b/42manito/src/components/Profile/UserProfile.tsx
@@ -26,7 +26,11 @@ export default function UserProfile() {
     <Layout>
       {OwnerData && !OwnerLoading && (
         <div className="app-container pt-32">
-          <div className="flex flex-wrap flex-col items-center justify-center mt-5 mb-12 w-[70vw] rounded-2xl bg-gray-200">
+          <div
+            className="flex flex-wrap flex-col items-center justify-center mt-5 mb-12
+            w-[80vw] rounded-2xl bg-gray-100 dark:bg-gray-900
+            drop-shadow-2xl"
+          >
             <div className="md:flex flex-wrap w-full items-center justify-center mt-12">
               <ProfileImage src={OwnerData.profileImage} />
               <ProfileInfo
@@ -34,7 +38,13 @@ export default function UserProfile() {
                 count={OwnerData.mentorProfile.mentoringCount}
               />
             </div>
-            <div className="flex flex-wrap items-center justify-center w-[50vw] mt-10 mb-14">
+            <div
+              className="flex flex-wrap justify-center
+                w-[80%] break-all px-3 py-4
+                mt-10 mb-14
+                rounded-2xl bg-gray-100 dark:bg-gray-800
+                shadow-sm"
+            >
               {OwnerData.mentorProfile.shortDescription ??
                 "짧은 소개글이 없습니다."}
             </div>
@@ -42,7 +52,7 @@ export default function UserProfile() {
               categories={OwnerData.mentorProfile.categories}
             />
             <ProfileHashtag hashtag={OwnerData.mentorProfile.hashtags} />
-            <div className="flex flex-wrap flex-col items-center justify-center w-[60vw] mb-10">
+            <div className="flex flex-wrap flex-col items-center justify-center w-[80%] mb-10">
               <div className="text-3xl font-bold">소개글</div>
               <div className="h-[1px] bg-slate-800 dark:bg-slate-50 w-[40vw] my-8" />
               <DescriptionComponent

--- a/42manito/src/components/Profile/UserProfile.tsx
+++ b/42manito/src/components/Profile/UserProfile.tsx
@@ -26,27 +26,25 @@ export default function UserProfile() {
     <Layout>
       {OwnerData && !OwnerLoading && (
         <div className="app-container pt-32">
-          <div className="flex flex-wrap items-center justify-center mt-12 w-[100vw] flex flex-col">
-            <div className="md:flex flex-wrap w-full items-center justify-center">
+          <div className="flex flex-wrap flex-col items-center justify-center mt-5 mb-12 w-[70vw] rounded-2xl bg-gray-200">
+            <div className="md:flex flex-wrap w-full items-center justify-center mt-12">
               <ProfileImage src={OwnerData.profileImage} />
               <ProfileInfo
                 nickname={OwnerData.nickname}
                 count={OwnerData.mentorProfile.mentoringCount}
               />
             </div>
-            <div className="flex flex-wrap w-full items-center justify-center w-[50vw] mt-10 mb-14">
-              <div className="">
-                {OwnerData.mentorProfile.shortDescription ??
-                  "짧은 소개글이 없습니다."}
-              </div>
+            <div className="flex flex-wrap items-center justify-center w-[50vw] mt-10 mb-14">
+              {OwnerData.mentorProfile.shortDescription ??
+                "짧은 소개글이 없습니다."}
             </div>
             <ProfileCategories
               categories={OwnerData.mentorProfile.categories}
             />
             <ProfileHashtag hashtag={OwnerData.mentorProfile.hashtags} />
-            <div className="flex flex-wrap items-center justify-center w-[50vw] mb-10">
+            <div className="flex flex-wrap flex-col items-center justify-center w-[60vw] mb-10">
               <div className="text-3xl font-bold">소개글</div>
-              <div className="h-[1px] bg-slate-800 dark:bg-slate-50 w-full my-8" />
+              <div className="h-[1px] bg-slate-800 dark:bg-slate-50 w-[40vw] my-8" />
               <DescriptionComponent
                 description={OwnerData.mentorProfile.description}
               />

--- a/42manito/src/components/Profile/UserProfile.tsx
+++ b/42manito/src/components/Profile/UserProfile.tsx
@@ -44,7 +44,7 @@ export default function UserProfile() {
               categories={OwnerData.mentorProfile.categories}
             />
             <ProfileHashtag hashtag={OwnerData.mentorProfile.hashtags} />
-            <div className="flex flex-wrap w-full items-center justify-center w-[50vw] mb-10">
+            <div className="flex flex-wrap items-center justify-center w-[50vw] mb-10">
               <div className="text-3xl font-bold">소개글</div>
               <div className="h-[1px] bg-slate-800 dark:bg-slate-50 w-full my-8" />
               <DescriptionComponent

--- a/42manito/src/pages/ProfileUpdate/[userId].tsx
+++ b/42manito/src/pages/ProfileUpdate/[userId].tsx
@@ -123,10 +123,17 @@ export default function ProfileUpdate() {
   return (
     <Layout>
       <section className="app-container pt-32">
-        <div className="flex flex-wrap items-center justify-center w-[60vw] mt-14">
-          <div className="mt-3 flex flex-col w-[90%]">
+        <div
+          className="flex flex-wrap flex-col items-center justify-center mt-14 mb-14
+             w-[80vw] rounded-2xl bg-gray-100 dark:bg-gray-900
+            drop-shadow-2xl"
+        >
+          <div className="text-3xl font-bold justify-center items-center mt-10">
+            프로필 변경하기
+          </div>
+          <div className="mt-10 flex flex-col w-[80%]">
             <div className="flex flex-row flex-wrap justify-between">
-              <div className="w-full text-3xl font-bold">카테고리</div>
+              <div className="w-full text-2xl font-bold">카테고리</div>
               <div className="flex flex-col md:flex-row my-3 overflow-y-auto mt-1">
                 {allCategories &&
                   allCategories.map((category, index) => (
@@ -155,7 +162,7 @@ export default function ProfileUpdate() {
               </div>
             </div>
             <div className="flex w-full flex-col">
-              <div className="w-full text-3xl font-bold mt-5">관심 분야</div>
+              <div className="w-full text-2xl font-bold mt-5">관심 분야</div>
               <div className="flex flex-row my-3 overflow-x-auto mt-1">
                 {formData &&
                   formData.hashtags.map((hashtag, index) => (
@@ -175,7 +182,7 @@ export default function ProfileUpdate() {
                     </HashtagCard>
                   ))}
               </div>
-              <div className="flex flex-row w-full justify-between items-center mt-1">
+              <div className="flex flex-row w-full justify-between items-center mb-5">
                 <TextArea
                   placeholder="Hashtag (3글자 이상, 한영, 숫자): ex) frontend"
                   maxLength={20}
@@ -200,7 +207,7 @@ export default function ProfileUpdate() {
               </div>
             </div>
             <div className="w-full mt-5">
-              <div className="w-full text-3xl font-bold mb-5">짧은 소개글</div>
+              <div className="w-full text-2xl font-bold mb-5">짧은 소개글</div>
               <TextArea
                 showCount
                 maxLength={50}
@@ -217,21 +224,22 @@ export default function ProfileUpdate() {
               />
             </div>
             <div className="w-full mt-5">
-              <div className="w-full text-3xl font-bold mb-5">소개글</div>
+              <div className="w-full text-2xl font-bold mb-5">소개글</div>
               <TextArea
                 placeholder="최대2000"
                 showCount
-                value={Description}
                 maxLength={2000}
+                value={Description}
                 style={{
                   height: 160,
                   marginBottom: 24,
                 }}
+                className="whitespace-pre-wrap"
                 onChange={(e) => setDescription(e.target.value.slice(0, 2000))}
               />
             </div>
           </div>
-          <div className="flex w-full justify-center mt-3 mb-5">
+          <div className="flex flex-row mt-3 mb-10 space-x-4">
             <Button
               className="text-xs  md:text-s bg-gray-500 hover:bg-gray-600 active:bg-gray-600 uppercase text-white font-bold hover:shadow-md shadow px-4 py-2 rounded outline-none focus:outline-none sm:mr-2 mb-1 ease-linear transition-all duration-150"
               type="button"

--- a/42manito/src/pages/ProfileUpdate/[userId].tsx
+++ b/42manito/src/pages/ProfileUpdate/[userId].tsx
@@ -51,7 +51,7 @@ export default function ProfileUpdate() {
 
     if (
       !doesHashtagExist &&
-      hashTagName.length >= 2 &&
+      hashTagName.length > 2 &&
       !regex.test(hashTagName)
     ) {
       // 입력된 해시태그가 위의 조건들을 만족하면 새로운 해시태그 추가

--- a/42manito/src/pages/ProfileUpdate/[userId].tsx
+++ b/42manito/src/pages/ProfileUpdate/[userId].tsx
@@ -184,7 +184,7 @@ export default function ProfileUpdate() {
               </div>
               <div className="flex flex-row w-full justify-between items-center mb-5">
                 <TextArea
-                  placeholder="Hashtag (3글자 이상, 한영, 숫자): ex) frontend"
+                  placeholder="ex) frontend"
                   maxLength={20}
                   value={hashTagName}
                   onChange={(e) => {

--- a/42manito/src/pages/ProfileUpdate/[userId].tsx
+++ b/42manito/src/pages/ProfileUpdate/[userId].tsx
@@ -187,7 +187,8 @@ export default function ProfileUpdate() {
                   onPressEnter={(e) => {
                     hashtagPostHandler();
                   }}
-                  className="mr-3 w-full whitespace-pre-wrap"
+                  className="mr-3 resize-none h-0.5 w-full whitespace-pre-wrap"
+                  style={{ height: 16 }}
                 />
                 <Button
                   onClick={() => hashtagPostHandler()}

--- a/42manito/src/pages/ProfileUpdate/[userId].tsx
+++ b/42manito/src/pages/ProfileUpdate/[userId].tsx
@@ -127,7 +127,7 @@ export default function ProfileUpdate() {
           <div className="mt-3 flex flex-col w-[90%]">
             <div className="flex flex-row flex-wrap justify-between">
               <div className="w-full text-3xl font-bold">카테고리</div>
-              <div className="flex flex-col md:flex-row my-3 overflow-y-auto mt-5">
+              <div className="flex flex-col md:flex-row my-3 overflow-y-auto mt-1">
                 {allCategories &&
                   allCategories.map((category, index) => (
                     <CategoryCard
@@ -156,7 +156,7 @@ export default function ProfileUpdate() {
             </div>
             <div className="flex w-full flex-col">
               <div className="w-full text-3xl font-bold mt-5">관심 분야</div>
-              <div className="flex flex-row my-3 overflow-x-auto mt-5">
+              <div className="flex flex-row my-3 overflow-x-auto mt-1">
                 {formData &&
                   formData.hashtags.map((hashtag, index) => (
                     <HashtagCard hashtag={hashtag.name} key={index}>
@@ -175,7 +175,7 @@ export default function ProfileUpdate() {
                     </HashtagCard>
                   ))}
               </div>
-              <div className="flex flex-row w-full justify-between items-center my-2">
+              <div className="flex flex-row w-full justify-between items-center mt-1">
                 <TextArea
                   placeholder="Hashtag (3글자 이상, 한영, 숫자): ex) frontend"
                   maxLength={20}

--- a/42manito/src/pages/ProfileUpdate/[userId].tsx
+++ b/42manito/src/pages/ProfileUpdate/[userId].tsx
@@ -124,7 +124,7 @@ export default function ProfileUpdate() {
     <Layout>
       <section className="app-container pt-32">
         <div
-          className="flex flex-wrap flex-col items-center justify-center mt-14 mb-14
+          className="flex flex-wrap flex-col items-center justify-center mt-5 mb-14
              w-[80vw] rounded-2xl bg-gray-100 dark:bg-gray-900
             drop-shadow-2xl"
         >

--- a/42manito/src/styles/globals.css
+++ b/42manito/src/styles/globals.css
@@ -356,6 +356,30 @@ p {
   }
 }
 
+.ant-input {
+  @apply  dark:bg-slate-800
+          dark:text-slate-200
+          dark:border-slate-800
+          dark:placeholder-slate-200
+          dark:focus:placeholder-slate-200
+          dark:focus:border-sky-800
+          dark:hover:border-sky-800
+}
+
+.ant-input-show-count,
+.ant-input-affix-wrapper
+{
+  @apply  dark:bg-slate-800
+        dark:text-slate-200
+        dark:border-slate-800
+        dark:placeholder-slate-200
+        dark:hover:placeholder-slate-200
+        dark:hover:border-sky-800
+}
+
+.ant-input-affix-wrapper-focused {
+  @apply dark:border-sky-800;
+}
 .ant-input-data-count {
   @apply text-slate-800 dark:text-slate-200;
 }


### PR DESCRIPTION
## Description
- Description 이 창 전체 폭에 맞춰 확장되는 문제를 수정했습니다.
- Hashtag 제약 조건 버그를 해소했습니다.
- Hashtag를 클릭하면 해당 해시태그를 가진 멘토를 검색하는 페이지로 이동합니다.
- Profile 이 하나의 사각형에 감싸져있는 형태를 유지합니다.
- Profile 아래 수정하기 버튼과 공개하기 버튼의 간격을 조절했습니다.
- ProfileUpdate 도 마찬가지로 사각형에 감싸져있는 형태를 유지합니다.
- ProfileUpdate 의 태그의 round가 더 둥글어졌습니다.
- ProfileUpdate 의 해시태그 추가 텍스트 영역이 작아졌습니다.
- ProfileUpdate 의 텍스트 영역에 다크모드에 맞는 CSS를 추가했습니다.

## 변경 예시
- <img width="262" alt="image" src="https://github.com/manito42/FrontEnd/assets/81505228/004d5585-cbdc-446d-918b-76bb29086f99">
- <img width="267" alt="image" src="https://github.com/manito42/FrontEnd/assets/81505228/0001a399-0611-415d-8606-c2a322864710">
- <img width="299" alt="image" src="https://github.com/manito42/FrontEnd/assets/81505228/1468282c-736b-4afa-836d-32e38d192831">


