### PR TITLE
:bug: [fix]: 이미 예약한 reservation 409 처리를 하지 못하는 문제 수정함.

### DIFF
--- a/42manito/src/components/Mentor/Modal.tsx
+++ b/42manito/src/components/Mentor/Modal.tsx
@@ -6,6 +6,7 @@ import { usePostReservationRequestMutation } from "@/RTK/Apis/Enroll";
 import { initMentorConnect } from "@/RTK/Slices/MentorConnect";
 import ConnectModal from "../Connect/ConnectModal";
 import UserProfile from "@/components/Profile/UserProfile";
+import { BaseQueryError } from "@reduxjs/toolkit/src/query/baseQueryTypes";
 
 const MentorModal = () => {
   const [closeAnimation, setCloseAnimation] = useState(false);
@@ -54,14 +55,22 @@ const MentorModal = () => {
     ) {
       alert("요청 메세지와 해시태그를 입력해주세요.");
     } else {
-      // FIXME: 이미 예약이 존재할 경우 409 처리가 되지 않음.
-      await postReservation({
-        mentorId: userId,
-        menteeId: Owner,
-        categoryId: connectState.categoryId, // 카테고리 선택할 수 있게 해야함
-        requestMessage: connectState.message, // 요청 메세지
-        hashtags: connectState.hashtags, // 해시태그
-      });
+      try {
+        await postReservation({
+          mentorId: userId,
+          menteeId: Owner,
+          categoryId: connectState.categoryId, // 카테고리 선택할 수 있게 해야함
+          requestMessage: connectState.message, // 요청 메세지
+          hashtags: connectState.hashtags, // 해시태그
+        }).unwrap();
+        alert("예약이 완료되었습니다.");
+      } catch (e: BaseQueryError<any>) {
+        if (e.status === 409) {
+          alert("이미 예약이 완료된 멘토입니다.");
+        } else {
+          alert("예약이 실패하였습니다.");
+        }
+      }
       handleConnectClose();
     }
   };

--- a/42manito/src/utils/BaseQuery.ts
+++ b/42manito/src/utils/BaseQuery.ts
@@ -10,7 +10,7 @@ export interface ErrorResponse {
 
 export const BaseQuery =
   (
-    { baseUrl }: { baseUrl: string } = { baseUrl: "" }
+    { baseUrl }: { baseUrl: string } = { baseUrl: "" },
   ): BaseQueryFn<
     {
       url: string;
@@ -54,8 +54,6 @@ export const BaseQuery =
         alert("서버에 오류가 발생했습니다.");
       } else if (err.status === 503) {
         alert("서버가 점검중입니다.");
-      } else {
-        alert("알 수 없는 오류가 발생했습니다.");
       }
 
       return {


### PR DESCRIPTION
## Description
- 중복 멘토링 신청 케이스의 경우 409 error 가 반환되는데 이 에러 핸들링을 하지 못하는 문제가 있었습니다.
- BaseQuery 의 불필요한 alert 를 제거하고 try catch 를 통해서 핸들링 할 수 있도록 했습니다.