### PR TITLE
:fire: [Fix]: 해시태그 클릭시 이동하는 로직 삭제

### DIFF
--- a/42manito/src/components/Profile/Hashtag.tsx
+++ b/42manito/src/components/Profile/Hashtag.tsx
@@ -1,31 +1,18 @@
 import { HashtagResponseDto } from "@/Types/Hashtags/HashtagResponse.dto";
 import React from "react";
-import { useRouter } from "next/router";
 
 interface props {
   hashtag: HashtagResponseDto[];
-  onClick?: (hashtag: string) => void;
 }
 
-export default function ProfileHashtag({ hashtag, onClick }: props) {
-  const router = useRouter();
-  const handleClick = onClick
-    ? onClick
-    : (hashtag: string) => {
-        router.push(`/Search/${hashtag}`);
-      };
-
+export default function ProfileHashtag({ hashtag }: props) {
   return (
     <div className="ProfileTagListWrapper">
       {hashtag.length > 0 &&
         hashtag.map((aTag) => (
-          <button
-            className="ProfileTag ProfileHashtagTag"
-            key={aTag.id}
-            onClick={() => handleClick(aTag.name)}
-          >
+          <div className="ProfileTag ProfileHashtagTag" key={aTag.id}>
             {aTag.name}
-          </button>
+          </div>
         ))}
     </div>
   );

--- a/42manito/src/pages/ProfileUpdate/[userId].tsx
+++ b/42manito/src/pages/ProfileUpdate/[userId].tsx
@@ -3,10 +3,7 @@ import {
   usePostHashtagMutation,
   useSetUserUpdateMutation,
 } from "@/RTK/Apis/User";
-import {
-  deleteOneHashtag,
-  ProfileUpdateSlice,
-} from "@/RTK/Slices/ProfileUpdate";
+import { ProfileUpdateSlice } from "@/RTK/Slices/ProfileUpdate";
 import { RootState, useAppDispatch } from "@/RTK/store";
 import { MentorProfilePatchReqDto } from "@/Types/MentorProfiles/MentorProfilePatchReq.dto";
 import { Button } from "@/common";
@@ -141,12 +138,7 @@ export default function ProfileUpdate() {
             <div className="w-[90vw] ProfileTagWrapper">
               <span className="ProfileHeader">관심분야</span>
               <span className="ProfileSmall">태그를 클릭하면 사라집니다</span>
-              <ProfileHashtag
-                hashtag={formData.hashtags}
-                onClick={(h) => {
-                  dispatch(deleteOneHashtag(h));
-                }}
-              />
+              <ProfileHashtag hashtag={formData.hashtags} />
               <HashtagUpdateInput hashtags={formData.hashtags} />
             </div>
 


### PR DESCRIPTION
## 문제
- 모달이 띄워진 상태에서 해시태그 클릭 시 이동하면 뒤쪽 페이지만 넘어가고 모달은 남는 문제가 발생합니다.

## 변경사항
- 해시태그 클릭 시 아무 일도 일어나지 않습니다.
  - 나중에 해봅시다.