### PR TITLE
[UI/Refactor] Header 요소 위치 변경

### DIFF
--- a/42manito/src/components/Layout/Header/components/Sidebar.tsx
+++ b/42manito/src/components/Layout/Header/components/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { signOut } from "@/RTK/Slices/Global";
 import { RootState, useAppDispatch } from "@/RTK/store";
 import { SignIn } from "@/utils/SignIn";
-import { Divider } from "antd";
 import Link from "next/link";
 import React from "react";
 import { useSelector } from "react-redux";
@@ -42,7 +41,6 @@ export default function Sidebar({ onClose }: props) {
           <p className="sidebar-text sidebar-text-btn">Profile</p>
         </Link>
       )}
-      <Divider className="dark:bg-bg_color-400 bg-bg_color-500 my-16" />
       {Owner === 0 && (
         <button
           id="42AuthSignIn"

--- a/42manito/src/components/Layout/Header/components/Sidebar.tsx
+++ b/42manito/src/components/Layout/Header/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { Divider } from "antd";
 import Link from "next/link";
 import React from "react";
 import { useSelector } from "react-redux";
+import SearchInput from "@/components/Search/SearchInput";
 
 interface props {
   onClose: () => void;
@@ -27,6 +28,9 @@ export default function Sidebar({ onClose }: props) {
   };
   return (
     <>
+      <div className="my-1 flex justify-center">
+        <SearchInput />
+      </div>
       <Link href="/" onClick={onClose}>
         <p className="sidebar-text sidebar-text-btn">Home</p>
       </Link>
@@ -38,9 +42,6 @@ export default function Sidebar({ onClose }: props) {
           <p className="sidebar-text sidebar-text-btn">Profile</p>
         </Link>
       )}
-      <Link href="/Categories" onClick={onClose}>
-        <p className="sidebar-text sidebar-text-btn">Category</p>
-      </Link>
       <Divider className="dark:bg-bg_color-400 bg-bg_color-500 my-16" />
       {Owner === 0 && (
         <button

--- a/42manito/src/components/Layout/Header/index.tsx
+++ b/42manito/src/components/Layout/Header/index.tsx
@@ -4,7 +4,6 @@ import { Drawer } from "antd";
 import { RootState, useAppDispatch } from "@/RTK/store";
 import { signIn } from "@/RTK/Slices/Global";
 import { useSelector } from "react-redux";
-import SearchInput from "../../Search/SearchInput";
 import Sidebar from "./components/Sidebar";
 
 export default function Header() {
@@ -35,15 +34,29 @@ export default function Header() {
     <>
       <header className="layout-header">
         <div className="layout-header-container ">
+          <div className="flex justify-start absolute w-full">
+            <button onClick={showSidebar} className="layout-sidebar-btn my-1">
+              <svg
+                width="45px"
+                height="45px"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+                className="svg-side-bar"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M5 7C5 6.44772 5.44772 6 6 6H18C18.5523 6 19 6.44772 19 7C19 7.55228 18.5523 8 18 8H6C5.44772 8 5 7.55228 5 7ZM5 12C5 11.4477 5.44772 11 6 11H18C18.5523 11 19 11.4477 19 12C19 12.5523 18.5523 13 18 13H6C5.44772 13 5 12.5523 5 12ZM5 17C5 16.4477 5.44772 16 6 16H18C18.5523 16 19 16.4477 19 17C19 17.5523 18.5523 18 18 18H6C5.44772 18 5 17.5523 5 17Z"
+                />
+              </svg>
+            </button>
+          </div>
           <Link
             href="/"
-            className="flex title-font font-medium items-center mb-4 md:mb-0"
+            className="flex flex-wrap title-font font-medium items-center z-10"
           >
             <span className=" text-2xl hover:text-indigo-500">42Manito</span>
           </Link>
-          <div className="my-1 flex justify-center">
-            <SearchInput />
-          </div>
           <Drawer
             className="dark:bg-bg_color-600 px-4 fade-in md:pt-10"
             placement="right"
@@ -53,21 +66,6 @@ export default function Header() {
           >
             <Sidebar onClose={onClose} />
           </Drawer>
-          <button onClick={showSidebar} className="layout-sidebar-btn">
-            <svg
-              width="45px"
-              height="45px"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-              className="svg"
-            >
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M5 7C5 6.44772 5.44772 6 6 6H18C18.5523 6 19 6.44772 19 7C19 7.55228 18.5523 8 18 8H6C5.44772 8 5 7.55228 5 7ZM5 12C5 11.4477 5.44772 11 6 11H18C18.5523 11 19 11.4477 19 12C19 12.5523 18.5523 13 18 13H6C5.44772 13 5 12.5523 5 12ZM5 17C5 16.4477 5.44772 16 6 16H18C18.5523 16 19 16.4477 19 17C19 17.5523 18.5523 18 18 18H6C5.44772 18 5 17.5523 5 17Z"
-              />
-            </svg>
-          </button>
         </div>
       </header>
     </>

--- a/42manito/src/components/Layout/Layout.tsx
+++ b/42manito/src/components/Layout/Layout.tsx
@@ -10,7 +10,7 @@ export default function Layout({ children }: Props) {
   return (
     <div className="layout">
       <Header />
-      <div>{children}</div>
+      {children}
       <Footer />
     </div>
   );

--- a/42manito/src/components/Search/MentorList.tsx
+++ b/42manito/src/components/Search/MentorList.tsx
@@ -16,18 +16,25 @@ export default function SearchMentorList({
   hasMore,
 }: props) {
   return (
-    <InfiniteScroll
-      dataLength={searchMentors.length}
-      next={fetchMoreData}
-      hasMore={hasMore}
-      loader={<Spin />}
-      height={"100%"}
-    >
-      <div className="mentor-cards-container">
-        {searchMentors.map((mentor) => (
-          <MentorCard data={mentor} key={mentor.id} />
-        ))}
-      </div>
-    </InfiniteScroll>
+    <>
+      <InfiniteScroll
+        dataLength={searchMentors.length}
+        next={fetchMoreData}
+        hasMore={hasMore}
+        scrollThreshold={0.9}
+        style={{ overflow: "hidden" }}
+        loader={
+          <div className="flex justify-center">
+            <Spin />
+          </div>
+        }
+      >
+        <div className="mentor-cards-container">
+          {searchMentors.map((mentor) => (
+            <MentorCard data={mentor} key={mentor.id} />
+          ))}
+        </div>
+      </InfiniteScroll>
+    </>
   );
 }

--- a/42manito/src/hooks/Home/FetchHome.tsx
+++ b/42manito/src/hooks/Home/FetchHome.tsx
@@ -16,6 +16,7 @@ export const useFetchHome = (categoryId?: number | undefined) => {
   };
 
   const fetchMoreData = () => {
+    console.log("fetchMoreData");
     getMentors({ take: 12, page: page + 1, category_id: categoryId });
     setPage(page + 1);
   };
@@ -27,5 +28,5 @@ export const useFetchHome = (categoryId?: number | undefined) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading]);
 
-  return { newMentor, isLoading, fetchNewCategory, fetchMoreData };
+  return { newMentor, fetchNewCategory, fetchMoreData };
 };

--- a/42manito/src/hooks/Home/FetchHome.tsx
+++ b/42manito/src/hooks/Home/FetchHome.tsx
@@ -1,27 +1,31 @@
-import { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "@/RTK/store";
+import React, { useEffect } from "react";
 import { useGetMentorsMutation } from "@/RTK/Apis/Home";
-import { setAllMentor } from "@/RTK/Slices/Home";
+import { MentorProfileDto } from "@/Types/MentorProfiles/MentorProfile.dto";
 
 export const useFetchHome = (categoryId?: number | undefined) => {
-  const allMentor = useSelector(
-    (state: RootState) => state.rootReducers.home.allMentor,
-  );
-  const dispatch = useDispatch();
+  const [newMentor, setNewMentor] = React.useState<
+    MentorProfileDto[] | undefined
+  >(undefined);
   const [getMentors, { data: mentors, isLoading, error }] =
     useGetMentorsMutation();
+  const [page, setPage] = React.useState<number>(0);
 
   const fetchNewCategory = () => {
     getMentors({ take: 12, page: 0, category_id: categoryId });
+    setPage(0);
+  };
+
+  const fetchMoreData = () => {
+    getMentors({ take: 12, page: page + 1, category_id: categoryId });
+    setPage(page + 1);
   };
 
   useEffect(() => {
-    if (mentors && !error) {
-      dispatch(setAllMentor(mentors));
+    if (mentors && !error && !isLoading) {
+      setNewMentor(mentors);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading]);
 
-  return { allMentor, fetchNewCategory };
+  return { newMentor, isLoading, fetchNewCategory, fetchMoreData };
 };

--- a/42manito/src/pages/Search/[searchKeyword].tsx
+++ b/42manito/src/pages/Search/[searchKeyword].tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import React, { useEffect } from "react";
 import { useSelector } from "react-redux";
 import { useFetchSearch } from "@/hooks/Search/FetchSearch";
+import SearchInput from "@/components/Search/SearchInput";
 
 const Search: React.FC = () => {
   const router = useRouter();
@@ -42,7 +43,10 @@ const Search: React.FC = () => {
     <>
       <Layout>
         <div className="app-container">
-          <div className="search-header-text">
+          <div className="search-input-wrapper">
+            <SearchInput />
+          </div>
+          <div className="search-header-text items-center">
             <span className="text-bg_color-400">{`"${searchKeyword}"`} </span>
             {"  검색 결과"}
           </div>

--- a/42manito/src/pages/Search/[searchKeyword].tsx
+++ b/42manito/src/pages/Search/[searchKeyword].tsx
@@ -65,7 +65,7 @@ const Search: React.FC = () => {
         </div>
         <button
           onClick={scrollToTop}
-          className="fixed bottom-5 right-5 rounded-full bg-indigo-500 hover:bg-indigo-600 text-white text-center w-[4vw] h-[4vw] min-w-[55px] min-h-[55px] text-4xl font-bold z-50"
+          className="fixed bottom-5 right-5 rounded-full bg-signature_color-500 hover:bg-signature_color-600 text-white text-center w-[4vw] h-[4vw] min-w-[55px] min-h-[55px] text-4xl font-bold z-50"
         >
           ↑
         </button>

--- a/42manito/src/pages/index.tsx
+++ b/42manito/src/pages/index.tsx
@@ -27,9 +27,11 @@ export default function Home() {
   const [categoryId, setCategoryId] = React.useState<number>(0);
   const { data: Categories } = useGetCategoriesQuery();
   const currMentorState = useMentorModal();
-  const { newMentor, isLoading, fetchNewCategory, fetchMoreData } =
+  const { newMentor, fetchNewCategory, fetchMoreData } =
     useFetchHome(categoryId);
-  const [mentorList, setMentorList] = useState<MentorProfileDto[]>([]);
+  const [mentorList, setMentorList] = useState<MentorProfileDto[] | undefined>(
+    undefined,
+  );
 
   useEffect(() => {
     if (OwnerId === 0) {
@@ -44,16 +46,17 @@ export default function Home() {
   }, [OwnerId, dispatch]);
 
   useEffect(() => {
-    fetchNewCategory();
     setHasMore(true);
+    fetchNewCategory();
+    setMentorList(undefined);
     return () => {
-      setMentorList([]);
+      setMentorList(undefined);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [categoryId, dispatch]);
+  }, [categoryId]);
 
   useEffect(() => {
-    if (newMentor && !isLoading) {
+    if (newMentor) {
       if (newMentor.length < 12) {
         setHasMore(false);
       }
@@ -64,7 +67,7 @@ export default function Home() {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [newMentor, isLoading]);
+  }, [newMentor]);
 
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -74,7 +77,6 @@ export default function Home() {
     setCategoryId(categoryId);
   };
 
-  console.log(hasMore);
   return (
     <Layout>
       <div className="app-container">
@@ -107,7 +109,7 @@ export default function Home() {
         </div>
         <div className="home-mentor-profile-list">
           {mentorList === undefined && (
-            <div className="mentor-cards-container h-[300px]">
+            <div className="mentor-cards-container">
               <Spin />
             </div>
           )}
@@ -123,12 +125,13 @@ export default function Home() {
               dataLength={mentorList.length}
               next={fetchMoreData}
               hasMore={hasMore}
+              scrollThreshold={0.9}
+              style={{ overflow: "hidden" }}
               loader={
-                <div className="mentor-cards-container h-[300px]">
+                <div className="flex justify-center">
                   <Spin />
                 </div>
               }
-              height={"100%"}
             >
               <div className="mentor-cards-container">
                 {mentorList.map((mentor) => (

--- a/42manito/src/pages/index.tsx
+++ b/42manito/src/pages/index.tsx
@@ -59,6 +59,8 @@ export default function Home() {
       }
       if (mentorList) {
         setMentorList([...mentorList, ...newMentor]);
+      } else {
+        setMentorList(newMentor);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -72,7 +74,7 @@ export default function Home() {
     setCategoryId(categoryId);
   };
 
-  // 아직 테스트해야할게 많음 특히 Auth, ProfileUpdate
+  console.log(hasMore);
   return (
     <Layout>
       <div className="app-container">
@@ -104,10 +106,16 @@ export default function Home() {
           </div>
         </div>
         <div className="home-mentor-profile-list">
-          {mentorList === undefined && <Spin />}
+          {mentorList === undefined && (
+            <div className="mentor-cards-container h-[300px]">
+              <Spin />
+            </div>
+          )}
           {mentorList && mentorList.length === 0 && (
             <div className="mentor-cards-container mt-10 mb-20">
-              {"해당 영역의 멘토가 존재하지 않습니다."}
+              <div className="flex justify-center items-center w-full">
+                해당 영역의 멘토가 존재하지 않습니다.
+              </div>
             </div>
           )}
           {mentorList && mentorList.length !== 0 && (
@@ -115,7 +123,11 @@ export default function Home() {
               dataLength={mentorList.length}
               next={fetchMoreData}
               hasMore={hasMore}
-              loader={<Spin />}
+              loader={
+                <div className="mentor-cards-container h-[300px]">
+                  <Spin />
+                </div>
+              }
               height={"100%"}
             >
               <div className="mentor-cards-container">

--- a/42manito/src/pages/index.tsx
+++ b/42manito/src/pages/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { RootState, useAppDispatch } from "@/RTK/store";
 import dynamic from "next/dynamic";
-import { initAllMentor, setAllMentor } from "@/RTK/Slices/Home";
+import { initAllMentor } from "@/RTK/Slices/Home";
 import { signIn } from "@/RTK/Slices/Global";
 import { useMentorModal } from "@/hooks/Mentor/MentorModal";
 import { useFetchHome } from "@/hooks/Home/FetchHome";
@@ -70,8 +70,6 @@ export default function Home() {
   const handleCategoryClick = (categoryId: number) => {
     setCategoryId(categoryId);
   };
-
-  console.log(newMentor, hasMore);
 
   // 아직 테스트해야할게 많음 특히 Auth, ProfileUpdate
   return (

--- a/42manito/src/pages/index.tsx
+++ b/42manito/src/pages/index.tsx
@@ -95,7 +95,7 @@ export default function Home() {
           <div className="home-text-header">당신을 기다리는 멘토들</div>
           <div className="home-category-wrapper">
             <div className="home-text-detail">
-              원하는 영역의 멘토를 골라보세요
+              원하는 영역의 멘토를 찾아보세요
             </div>
             <CategoryIconList
               categories={Categories}

--- a/42manito/src/pages/index.tsx
+++ b/42manito/src/pages/index.tsx
@@ -61,7 +61,8 @@ export default function Home() {
         setMentorList([...mentorList, ...newMentor]);
       }
     }
-  }, [newMentor]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [newMentor, isLoading]);
 
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });

--- a/42manito/src/styles/globals.css
+++ b/42manito/src/styles/globals.css
@@ -11,7 +11,6 @@
 @import "./cardhashtag.css";
 @import "./banner.css";
 @import "./layout.css";
-
 /* @import "./about.css"; */
 
 ::-webkit-scrollbar {
@@ -417,10 +416,4 @@ p {
 
 .ant-select-selection-placeholder {
   @apply dark:text-bg_color-200;
-}
-
-/* main wrapper */
-.app-container {
-  @apply flex flex-col justify-start items-center bg-bg_color-50 dark:bg-bg_color-800
-    min-h-screen;
 }

--- a/42manito/src/styles/layout.css
+++ b/42manito/src/styles/layout.css
@@ -1,5 +1,6 @@
 header {
-  @apply bg-bg_color-200 dark:bg-bg_color-900 pt-2 md:pt-0;
+  @apply bg-bg_color-200 dark:bg-bg_color-900 md:pt-0;
+
   .layout-header {
     @apply text-bg_color-600 grow
         w-full

--- a/42manito/src/styles/layout.css
+++ b/42manito/src/styles/layout.css
@@ -1,22 +1,19 @@
 header {
   @apply bg-bg_color-200 dark:bg-bg_color-900 pt-2 md:pt-0;
   .layout-header {
-    @apply text-bg_color-600
+    @apply text-bg_color-600 grow
         w-full
         z-[10];
   }
 
   .layout-header-container {
-    @apply mx-auto py-2 flex flex-wrap
-          flex-col md:flex-row items-center justify-between
+    @apply mx-auto py-2 flex flex-wrap relative
+          flex-row items-center justify-center
           w-[90%] md:w-[600px] lg:w-[900px];
   }
   .layout-sidebar-btn {
-    @apply fixed bottom-5 right-5
-          flex justify-center items-center
-          rounded-full
-          bg-signature_color-500 dark:bg-signature_color-600 hover:bg-signature_color-600 dark:hover:bg-signature_color-700
-          w-[4vw] h-[4vw] min-w-[55px] min-h-[55px]
+    @apply flex justify-center items-center
+          w-[1vw] h-[1vw] min-w-[35px] min-h-[35px]
           z-50;
   }
 }
@@ -39,4 +36,17 @@ footer {
 
 .sidebar-text-btn:hover {
   @apply text-indigo-500 transition-all scale-x-110 scale-y-110;
+}
+
+.layout {
+  @apply min-h-screen flex flex-col justify-between items-stretch;
+}
+
+.svg-side-bar {
+  @apply fill-bg_color-900 dark:fill-bg_color-200;
+}
+
+/* main wrapper */
+.app-container {
+  @apply flex flex-col justify-start items-center bg-bg_color-50 dark:bg-bg_color-800 grow;
 }

--- a/42manito/src/styles/mentor.css
+++ b/42manito/src/styles/mentor.css
@@ -8,6 +8,10 @@
         rounded-xl m-2 shadow-sm;
 }
 
+.mentor-cards-container {
+  @apply flex flex-wrap justify-center items-center w-full mb-10;
+}
+
 .mentor-card-profile-info {
   @apply flex flex-row justify-start items-center w-[100%] h-[65%] px-2 mt-2;
 }

--- a/42manito/src/styles/mentor.css
+++ b/42manito/src/styles/mentor.css
@@ -9,7 +9,7 @@
 }
 
 .mentor-cards-container {
-  @apply flex flex-wrap justify-center items-center w-full mb-10;
+  @apply flex flex-wrap justify-center items-start w-full mb-10 min-h-[300px];
 }
 
 .mentor-card-profile-info {

--- a/42manito/src/styles/search.css
+++ b/42manito/src/styles/search.css
@@ -6,5 +6,5 @@
 }
 
 .search-container {
-  @apply flex flex-col items-center justify-center w-[80%] md:w-[900px];
+  @apply flex flex-col items-center justify-center w-[80%] md:w-[600px] lg:w-[900px] mx-auto;
 }

--- a/42manito/src/styles/search.css
+++ b/42manito/src/styles/search.css
@@ -1,11 +1,10 @@
+.search-input-wrapper {
+  @apply mt-5;
+}
 .search-header-text {
   @apply text-lg font-bold text-bg_color-800 dark:text-bg_color-200 m-5 whitespace-pre;
 }
 
 .search-container {
   @apply flex flex-col items-center justify-center w-[80%] md:w-[900px];
-}
-
-.mentor-cards-container {
-  @apply flex flex-wrap justify-center items-center w-full;
 }


### PR DESCRIPTION
## 변경 사항
- 햄버거의 위치를 floatting 하지않고 home 의 좌측으로 옮겼습니다.
- 42Manito 타이틀을 중앙으로 고정했습니다.
- SearchInput 의 위치를 Sidebar 안쪽으로 변경했습니다.
- Categories 를 지운 대신, Home 의 리스트에 모두 나올 수 있도록 변경했습니다.
  - 어차피 보여줄게 같다고 판단하여, 따로 관리하지 않고 홈에서 다 처리합니다.
    - Pagination 을 하려고 했으나, 백엔드 response 의 변경이 필요하여 일단 보류합니다. (당분간은 pagination이 필요할 만큼 멘토가 많지 않습니다.)
  - 이 과정에서 Home 에서 상태 관리 방식이 변경되었습니다.
  - useHomeFetch 및 홈 페이지는 더 이상 root store 의 allMentors 를 사용하지 않습니다.
  - 내부의 상태  mentorList 와 newMentor 를 통해서 관리합니다.
  - 사라졌던 최상위로 가는 토글 버튼을 Infinity scroll 이 있는 페이지에 다시 적용했습니다.

## Screenshot
<img width="355" alt="image" src="https://github.com/manito42/FrontEnd/assets/81505228/ab1db318-7eeb-4985-bf0b-442812c0612c">
<img width="332" alt="image" src="https://github.com/manito42/FrontEnd/assets/81505228/f5b0527c-5e7a-4ffc-934b-831f23addf9e">
<img width="530" alt="image" src="https://github.com/manito42/FrontEnd/assets/81505228/347da78c-1f0a-4825-a58d-09826b974500">

Closes #98