### PR TITLE
[fix] login logout #144

### DIFF
--- a/42manito/env.sample
+++ b/42manito/env.sample
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_GA_ID=""
+NEXT_PUBLIC_DEV_URL="https://api.dev.42manito.com"

--- a/42manito/src/components/Layout/Header/index.tsx
+++ b/42manito/src/components/Layout/Header/index.tsx
@@ -18,14 +18,14 @@ export default function Header() {
   const [loading, setLoading] = useState(false);
   const dispatch = useAppDispatch();
   const router = useRouter();
-  const handleSingOut = async () => {
+  const handleSingOut = () => {
     const id = localStorage.getItem("uid");
     if (id) {
-      await localStorage.removeItem("uid");
-      await localStorage.removeItem("accessToken");
+      localStorage.removeItem("uid");
+      localStorage.removeItem("accessToken");
       dispatch(signOut());
-      if (router.pathname !== "/") location.href = "/";
-      else location.reload();
+      if (router.pathname !== "/") router.push("/");
+      else router.reload();
     }
   };
 

--- a/42manito/src/components/Layout/Header/index.tsx
+++ b/42manito/src/components/Layout/Header/index.tsx
@@ -17,7 +17,7 @@ export default function Header() {
   );
   const [loading, setLoading] = useState(false);
   const dispatch = useAppDispatch();
-
+  const router = useRouter();
   const handleSingOut = async () => {
     const id = localStorage.getItem("uid");
     if (id) {
@@ -62,23 +62,23 @@ export default function Header() {
             {Owner === 0 && (
               <button
                 id="42AuthSignIn"
-                className="layout-btn"
+                className="layout-btn layout-sign-btn"
                 onClick={() => {
                   onClose();
                   setLoading(true);
                   return SignIn();
                 }}
               >
-                <LockOutlined style={{ fontSize: 20 }} />
+                로그인
               </button>
             )}
             {Owner !== 0 && !Number.isNaN(Owner) && (
               <button
                 id="SignOut"
-                className="layout-btn"
+                className="layout-btn layout-sign-btn"
                 onClick={handleSingOut}
               >
-                <UnlockOutlined style={{ fontSize: 20 }} />
+                로그아웃
               </button>
             )}
           </div>

--- a/42manito/src/components/Layout/Header/index.tsx
+++ b/42manito/src/components/Layout/Header/index.tsx
@@ -6,17 +6,14 @@ import { signIn, signOut } from "@/RTK/Slices/Global";
 import { useSelector } from "react-redux";
 import Sidebar from "./components/Sidebar";
 import { SignIn } from "@/utils/SignIn";
-import {
-  LockOutlined,
-  UnlockOutlined,
-  UnorderedListOutlined,
-} from "@ant-design/icons";
+import { UnorderedListOutlined } from "@ant-design/icons";
 import Loading from "@/components/Global/Loading";
+import { useRouter } from "next/router";
 
 export default function Header() {
   const [visible, setVisible] = useState(false);
   const Owner = useSelector(
-    (state: RootState) => state.rootReducers.global.uId,
+    (state: RootState) => state.rootReducers.global.uId
   );
   const [loading, setLoading] = useState(false);
   const dispatch = useAppDispatch();
@@ -27,7 +24,8 @@ export default function Header() {
       await localStorage.removeItem("uid");
       await localStorage.removeItem("accessToken");
       dispatch(signOut());
-      location.reload();
+      if (router.pathname !== "/") location.href = "/";
+      else location.reload();
     }
   };
 

--- a/42manito/src/styles/layout.css
+++ b/42manito/src/styles/layout.css
@@ -14,8 +14,16 @@ header {
   }
   .layout-btn {
     @apply flex justify-center items-center
-          w-[1vw] h-[1vw] min-w-[35px] min-h-[35px]
+          min-w-[35px] min-h-[35px]
           z-50 my-1;
+  }
+  .layout-sign-btn {
+    @apply
+      border border-solid border-bg_color-300 py-1 px-2
+      font-light
+      rounded
+      text-sm
+      bg-bg_color-100;
   }
 }
 


### PR DESCRIPTION
- #144 
- 로그인 / 로그아웃 header 의 아이콘 변경 (텍스트가 포함된 형태로 변경)
- 로그인 / 로그아웃 시 home 으로 이동하도록 변경
- env sample 추가

<img width="1152" alt="image" src="https://github.com/manito42/FrontEnd/assets/81505228/1c940a1b-408c-4e53-ad10-638022a891d6">

<img width="380" alt="image" src="https://github.com/manito42/FrontEnd/assets/81505228/51753c37-8ebc-47a0-9b65-3ab87e4d52bc">
