### PR TITLE
[fix] ProfileUpdate에서의 소개글 글자수 제한 수정

### DIFF
--- a/42manito/src/pages/ProfileUpdate/[userId].tsx
+++ b/42manito/src/pages/ProfileUpdate/[userId].tsx
@@ -152,7 +152,7 @@ export default function ProfileUpdate() {
                 <TextArea
                   placeholder="소개글을 작성해주세요"
                   showCount
-                  maxLength={2000}
+                  maxLength={1000}
                   value={Description}
                   style={{
                     marginBottom: 15,

--- a/42manito/src/pages/ProfileUpdate/[userId].tsx
+++ b/42manito/src/pages/ProfileUpdate/[userId].tsx
@@ -150,7 +150,7 @@ export default function ProfileUpdate() {
               <div className="ProfileHeader mb-5">소개글</div>
               <div className="ProfileDescription">
                 <TextArea
-                  placeholder="최대2000"
+                  placeholder="소개글을 작성해주세요"
                   showCount
                   maxLength={2000}
                   value={Description}


### PR DESCRIPTION
기존의 글자수 제한이 2000자였지만 실제로는 1000자만 적용이 되었던 문제가 있었습니다.

따라서 ProfileUpdate에서 소개글 TextArea의 글자수 제한을 1000자로 수정하고,
그에 맞춰서 placeholder도 기존 "최대 2000자"에서 "소개글을 작성해 주세요"로 수정했습니다.

# Before
<img width="665" alt="image" src="https://github.com/manito42/FrontEnd/assets/52999093/25b4d8d2-6e70-46be-b491-8d5999bfc773">

# After
<img width="579" alt="image" src="https://github.com/manito42/FrontEnd/assets/52999093/fddba0f9-4e3d-4e43-9dfb-04f61065369c">
