### PR TITLE
[todo] 멘토링 취소 모달 개발

### DIFF
--- a/42manito/src/RTK/Apis/Reservation.ts
+++ b/42manito/src/RTK/Apis/Reservation.ts
@@ -80,6 +80,7 @@ export const reservationApi = createApi({
         return {
           url: `/reservations/${args.id}/cancel`,
           method: "PATCH",
+          data: {content: args.content},
         };
       },
       invalidatesTags: [{ type: "Reservation", id: "LIST" }],

--- a/42manito/src/RTK/Slices/Reservation.ts
+++ b/42manito/src/RTK/Slices/Reservation.ts
@@ -5,12 +5,14 @@ import { ReservationStatus } from "@/Types/Reservations/ReservationStatus";
 interface currMentorType {
   isReservationModalOpen: boolean;
   isFeedbackModalOpen: boolean;
+  isCancelModalOpen: boolean;
   selectedReservation: ReservationDefaultDto;
 }
 
 const InitialState: currMentorType = {
   isReservationModalOpen: false,
   isFeedbackModalOpen: false,
+  isCancelModalOpen: false,
   selectedReservation: {
     id: 0,
     mentorId: 0,
@@ -46,6 +48,12 @@ export const ReservationSlice = createSlice({
     closeFeedbackModal(state) {
       state.isFeedbackModalOpen = false;
     },
+    openCancelModal(state ) {
+      state.isCancelModalOpen = true;
+    },
+    closeCancelModal(state) {
+      state.isCancelModalOpen = false;
+    },
     setSelectedReservation(state, action) {
       state.selectedReservation = action.payload;
     },
@@ -57,5 +65,7 @@ export const {
   closeReservationModal,
   openFeedbackModal,
   closeFeedbackModal,
+  openCancelModal,
+  closeCancelModal,
   setSelectedReservation,
 } = ReservationSlice.actions;

--- a/42manito/src/Types/General/ButtonType.ts
+++ b/42manito/src/Types/General/ButtonType.ts
@@ -1,4 +1,4 @@
 export const enum ButtonType {
   ACCEPT,
-  CANCLE,
+  CANCEL,
 }

--- a/42manito/src/Types/Reservations/ReservationPatchCancelReq.dto.ts
+++ b/42manito/src/Types/Reservations/ReservationPatchCancelReq.dto.ts
@@ -1,3 +1,4 @@
 export interface ReservationPatchCancelReqDto {
   id: number;
+  content: string;
 }

--- a/42manito/src/components/Cancel/CancelMessageSelect.tsx
+++ b/42manito/src/components/Cancel/CancelMessageSelect.tsx
@@ -1,0 +1,36 @@
+import { Select } from "antd";
+import React, {Dispatch, SetStateAction} from "react";
+interface args{
+  setOpenTextArea: Dispatch<SetStateAction<boolean>>;
+  setCancelMsg: Dispatch<SetStateAction<string>>;
+}
+
+export default function CancelMessageSelect({setOpenTextArea, setCancelMsg} : args) {
+  const defaultMsg = [
+      {label: "시간이 맞지않아 취소합니다.", value: 1},
+      {label: "멘토/멘티로부터 연락이 없어서 취소합니다.", value: 2},
+      {label: "직접 입력", value: 3}
+  ]
+
+  const handleChange = (value: number) => {
+    const msgObj = defaultMsg.find(({value: id}) => id === value);
+    if (msgObj === undefined)
+      setCancelMsg("");
+    else
+      setCancelMsg(msgObj.label);
+    if (value === 3)
+      setOpenTextArea(true);
+    else
+      setOpenTextArea(false);
+  };
+
+  return (
+    <Select
+        defaultValue={1}
+        onChange={handleChange}
+        style={{ width: "100%" }}
+        options={defaultMsg}
+        className="w-full max-w-[500px]"
+    />
+  );
+}

--- a/42manito/src/components/Cancel/CancelModal.tsx
+++ b/42manito/src/components/Cancel/CancelModal.tsx
@@ -25,10 +25,10 @@ const CancelModal = () => {
         content: cancelMsg,
       }).unwrap();
       dispatch(setSelectedReservation(data));
-      alert(msg ? msg : "Success");
+      alert(msg ? msg : "멘토링이 취소되었습니다.");
       dispatch(closeCancelModal());
     } catch (e: BaseQueryError<any>) {
-      alert(errorMsg ? errorMsg : "Error");
+      alert(errorMsg ? errorMsg : "멘토링 취소가 실패했습니다.");
     }
   };
 

--- a/42manito/src/components/Cancel/CancelModal.tsx
+++ b/42manito/src/components/Cancel/CancelModal.tsx
@@ -53,10 +53,10 @@ const CancelModal = () => {
             <CancelMessageSelect setOpenTextArea={setOpenTextArea} setCancelMsg={setCancelMsg}/>
             {openTextArea && <Input.TextArea
               showCount
-              maxLength={1000}
+              maxLength={100}
               style={{ height: 80, marginBottom: 24 }}
               onChange={(e) => setCancelMsg(e.target.value)}
-              placeholder="최대 1000글자"
+              placeholder="최대 100글자"
               className="w-full max-w-[500px] mt-3"
             />}
           </div>

--- a/42manito/src/components/Cancel/CancelModal.tsx
+++ b/42manito/src/components/Cancel/CancelModal.tsx
@@ -62,7 +62,7 @@ const CancelModal = () => {
           </div>
           <div className="connect-btn-wrapper">
             <Button
-              buttonType={ButtonType.CANCLE}
+              buttonType={ButtonType.CANCEL}
               onClick={() => handleClose()}
             >
               닫기

--- a/42manito/src/components/Cancel/CancelModal.tsx
+++ b/42manito/src/components/Cancel/CancelModal.tsx
@@ -12,7 +12,7 @@ import {useSelector} from "react-redux";
 
 const CancelModal = () => {
   const [openTextArea, setOpenTextArea] = useState(false);
-  const [cancelMsg, setCancelMsg] = useState("");
+  const [cancelMsg, setCancelMsg] = useState("시간이 맞지않아 취소합니다.");
   const dispatch = useAppDispatch();
   const [patchCancelReservation] = usePatchReservationCancelMutation();
   const reservation = useSelector(

--- a/42manito/src/components/Cancel/CancelModal.tsx
+++ b/42manito/src/components/Cancel/CancelModal.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+import {RootState, useAppDispatch} from "@/RTK/store";
+import { Input } from "antd";
+import { Button } from "@/common";
+import { ButtonType } from "@/Types/General/ButtonType";
+import {closeCancelModal, setSelectedReservation} from "@/RTK/Slices/Reservation";
+import CancelMessageSelect from "@/components/Cancel/CancelMessageSelect";
+import { BaseQueryError } from "@reduxjs/toolkit/src/query/baseQueryTypes";
+import {usePatchReservationCancelMutation} from "@/RTK/Apis/Reservation";
+import {useSelector} from "react-redux";
+
+
+const CancelModal = () => {
+  const [openTextArea, setOpenTextArea] = useState(false);
+  const [cancelMsg, setCancelMsg] = useState("");
+  const dispatch = useAppDispatch();
+  const [patchCancelReservation] = usePatchReservationCancelMutation();
+  const reservation = useSelector(
+      (state: RootState) => state.rootReducers.reservation.selectedReservation,
+  );
+  const handleCancel = async (msg?: string, errorMsg?: string) => {
+    try {
+      const data = await patchCancelReservation({
+        id: reservation.id,
+        content: cancelMsg,
+      }).unwrap();
+      dispatch(setSelectedReservation(data));
+      alert(msg ? msg : "Success");
+      dispatch(closeCancelModal());
+    } catch (e: BaseQueryError<any>) {
+      alert(errorMsg ? errorMsg : "Error");
+    }
+  };
+
+  const handleClose = () => {
+    dispatch(closeCancelModal());
+  };
+
+  return (
+    <div
+      className="connect-wrapper"
+      id="wrapper"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <section
+        className={`connect-modal-section`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="connect-container">
+          <div className="connect-title mt-5"> 멘토링 취소</div>
+          <div className="connect-content-wrapper">
+            <div className="connect-header"> 취소하려는 이유를 선택해주세요 </div>
+            <CancelMessageSelect setOpenTextArea={setOpenTextArea} setCancelMsg={setCancelMsg}/>
+            {openTextArea && <Input.TextArea
+              showCount
+              maxLength={1000}
+              style={{ height: 80, marginBottom: 24 }}
+              onChange={(e) => setCancelMsg(e.target.value)}
+              placeholder="최대 1000글자"
+              className="w-full max-w-[500px] mt-3"
+            />}
+          </div>
+          <div className="connect-btn-wrapper">
+            <Button
+              buttonType={ButtonType.CANCLE}
+              onClick={() => handleClose()}
+            >
+              닫기
+            </Button>
+            <Button
+              buttonType={ButtonType.ACCEPT}
+              onClick={() => handleCancel()}
+            >
+              취소하기
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default CancelModal;

--- a/42manito/src/components/Connect/ConnectModal.tsx
+++ b/42manito/src/components/Connect/ConnectModal.tsx
@@ -65,7 +65,7 @@ const ConnectModal = ({ handleYes, children }: Props) => {
           </div>
           <div className="connect-btn-wrapper">
             <Button
-              buttonType={ButtonType.CANCLE}
+              buttonType={ButtonType.CANCEL}
               onClick={() => handleFocusOut()}
             >
               취소하기

--- a/42manito/src/components/Reservation/Reservation.tsx
+++ b/42manito/src/components/Reservation/Reservation.tsx
@@ -122,7 +122,7 @@ export default function Reservation({ children }: props) {
               (myRole === ReservationUserRole.mentor &&
                 status === ReservationStatus.ACCEPT)) && (
               <Button
-                buttonType={ButtonType.CANCLE}
+                buttonType={ButtonType.CANCEL}
                 onClick={() => {
                   dispatch(ReservationSlice.actions.openCancelModal());
                 }}

--- a/42manito/src/components/Reservation/Reservation.tsx
+++ b/42manito/src/components/Reservation/Reservation.tsx
@@ -11,12 +11,7 @@ import {
 import { ReservationStatus } from "@/Types/Reservations/ReservationStatus";
 import { Button } from "@/common";
 import NextProgressButton from "@/components/Reservation/NextProgressButton";
-import { usePatchReservationCancelMutation } from "@/RTK/Apis/Reservation";
-import {
-  ReservationSlice,
-  setSelectedReservation,
-} from "@/RTK/Slices/Reservation";
-import { BaseQueryError } from "@reduxjs/toolkit/src/query/baseQueryTypes";
+import { ReservationSlice } from "@/RTK/Slices/Reservation";
 import { RootState } from "@/RTK/store";
 import FeedbackCard from "@/components/Reservation/feedback/FeedbackCard";
 import { ButtonType } from "@/Types/General/ButtonType";
@@ -48,20 +43,8 @@ export default function Reservation({ children }: props) {
     targetUserRole === ReservationUserRole.mentor
       ? ReservationUserRole.mentee
       : ReservationUserRole.mentor;
-  const [patchCancelReservation] = usePatchReservationCancelMutation();
   const dispatch = useDispatch();
   const router = useRouter();
-  const handleCancelReservation = async (msg?: string, errorMsg?: string) => {
-    try {
-      const data = await patchCancelReservation({
-        id: reservation.id,
-      }).unwrap();
-      dispatch(setSelectedReservation(data));
-      alert(msg ? msg : "Success");
-    } catch (e: BaseQueryError<any>) {
-      alert(errorMsg ? errorMsg : "Error");
-    }
-  };
   const handleClick = (name: string) => {
     router.push(`/Search/${name}`);
     dispatch(ReservationSlice.actions.closeReservationModal());
@@ -138,10 +121,7 @@ export default function Reservation({ children }: props) {
               <Button
                 buttonType={ButtonType.CANCLE}
                 onClick={() => {
-                  handleCancelReservation(
-                    "취소 완료되었습니다.",
-                    "취소에 실패하였습니다.",
-                  );
+                  dispatch(ReservationSlice.actions.openCancelModal());
                 }}
               >
                 {myRole === ReservationUserRole.mentor &&

--- a/42manito/src/components/Reservation/modal/FeedbackModal.tsx
+++ b/42manito/src/components/Reservation/modal/FeedbackModal.tsx
@@ -116,7 +116,7 @@ const FeedbackModal = () => {
           </div>
           <div className="connect-btn-wrapper">
             <Button
-              buttonType={ButtonType.CANCLE}
+              buttonType={ButtonType.CANCEL}
               onClick={() => handleClose()}
             >
               취소하기

--- a/42manito/src/pages/Mentorings/index.tsx
+++ b/42manito/src/pages/Mentorings/index.tsx
@@ -10,6 +10,7 @@ import { ReservationStatus } from "@/Types/Reservations/ReservationStatus";
 import { useRouter } from "next/router";
 import Loading from "@/components/Global/Loading";
 import FeedbackModal from "@/components/Reservation/modal/FeedbackModal";
+import CancelModal from "@/components/Cancel/CancelModal";
 
 const Mentoring = () => {
   const banner = [
@@ -33,6 +34,9 @@ const Mentoring = () => {
   );
   const isFeedbackModalOpen = useSelector(
     (state: RootState) => state.rootReducers.reservation.isFeedbackModalOpen
+  );
+  const isCancelModalOpen = useSelector(
+      (state: RootState) => state.rootReducers.reservation.isCancelModalOpen
   );
   const handleRoleSelect = (id: string) => {
     if (id === "mentor") {
@@ -142,6 +146,7 @@ const Mentoring = () => {
         </div>
         {isReservationModalOpen && <ReservationModal />}
         {isFeedbackModalOpen && <FeedbackModal />}
+        {isCancelModalOpen && <CancelModal />}
       </Layout>
     </>
   );

--- a/42manito/src/pages/ProfileUpdate/[userId].tsx
+++ b/42manito/src/pages/ProfileUpdate/[userId].tsx
@@ -189,7 +189,7 @@ export default function ProfileUpdate() {
             </div>
             <div className="profile-update-btn-wrapper">
               <Button
-                buttonType={ButtonType.CANCLE}
+                buttonType={ButtonType.CANCEL}
                 type="button"
                 onClick={() => cancelButtonHandler()}
               >

--- a/42manito/src/pages/index.tsx
+++ b/42manito/src/pages/index.tsx
@@ -18,6 +18,7 @@ import { BannersData } from "@/components/Banners/Banners";
 import { ReservationRole } from "@/Types/Reservations/ReservationRole";
 import { ReservationStatus } from "@/Types/Reservations/ReservationStatus";
 import CancelModal from "@/components/Cancel/CancelModal";
+import FeedbackModal from "@/components/Reservation/modal/FeedbackModal";
 
 const MentorModal = dynamic(() => import("@/components/Mentor/Modal"));
 
@@ -36,6 +37,9 @@ export default function Home() {
   );
   const isReservationModalOpen = useSelector(
     (state: RootState) => state.rootReducers.reservation.isReservationModalOpen
+  );
+  const isFeedbackModalOpen = useSelector(
+      (state: RootState) => state.rootReducers.reservation.isFeedbackModalOpen
   );
   const isCancelModalOpen = useSelector(
       (state: RootState) => state.rootReducers.reservation.isCancelModalOpen,
@@ -151,6 +155,7 @@ export default function Home() {
           <MentorModal />
         )}
         {isReservationModalOpen && <ReservationModal />}
+        {isFeedbackModalOpen && <FeedbackModal />}
         {isCancelModalOpen && (<CancelModal />)}
         <button
           onClick={scrollToTop}

--- a/42manito/src/pages/index.tsx
+++ b/42manito/src/pages/index.tsx
@@ -17,6 +17,7 @@ import ReservationModal from "@/components/Reservation/modal/ReservationModal";
 import { BannersData } from "@/components/Banners/Banners";
 import { ReservationRole } from "@/Types/Reservations/ReservationRole";
 import { ReservationStatus } from "@/Types/Reservations/ReservationStatus";
+import CancelModal from "@/components/Cancel/CancelModal";
 
 const MentorModal = dynamic(() => import("@/components/Mentor/Modal"));
 
@@ -35,6 +36,9 @@ export default function Home() {
   );
   const isReservationModalOpen = useSelector(
     (state: RootState) => state.rootReducers.reservation.isReservationModalOpen
+  );
+  const isCancelModalOpen = useSelector(
+      (state: RootState) => state.rootReducers.reservation.isCancelModalOpen,
   );
   const requestQuery = {
     take: 100,
@@ -147,6 +151,7 @@ export default function Home() {
           <MentorModal />
         )}
         {isReservationModalOpen && <ReservationModal />}
+        {isCancelModalOpen && (<CancelModal />)}
         <button
           onClick={scrollToTop}
           className="fixed bottom-5 right-5 rounded-full

--- a/42manito/src/pages/reservation/[reservationId].tsx
+++ b/42manito/src/pages/reservation/[reservationId].tsx
@@ -7,6 +7,7 @@ import React, { useEffect } from "react";
 import Layout from "@/components/Layout/Layout";
 import FeedbackModal from "@/components/Reservation/modal/FeedbackModal";
 import { RootState } from "@/RTK/store";
+import CancelModal from "@/components/Cancel/CancelModal";
 
 export default function ReservationPage() {
   const route = useRouter();
@@ -20,6 +21,9 @@ export default function ReservationPage() {
   });
   const isFeedbackModalOpen = useSelector(
     (state: RootState) => state.rootReducers.reservation.isFeedbackModalOpen,
+  );
+  const isCancelModalOpen = useSelector(
+      (state: RootState) => state.rootReducers.reservation.isCancelModalOpen,
   );
   const dispatch = useDispatch();
 
@@ -35,6 +39,7 @@ export default function ReservationPage() {
           <div className="py-10">{!isLoading && !error && <Reservation />}</div>
         </div>
         {isFeedbackModalOpen && <FeedbackModal />}
+        {isCancelModalOpen && <CancelModal />}
       </Layout>
     </>
   );


### PR DESCRIPTION
# Summary
* 멘토링 취소 모달인 CancelModal을 추가했습니다.
* 홈 화면에 Feedback 모달을 추가했습니다.

# Description
1. 멘토링 취소 모달인 CancelModal을 추가했습니다.
해당 모달은 components/Cancel/CancelModal.tsx에 위치해 있습니다.
일단 취소 모달의 Select 항목의 내용은 기존 #190 에서 말해주셨던 항목을 참고했습니다.
해당 모달은 page/index.tsx, page/Mentorings/index.tsx, page/reservation/[reservationId].tsx에 추가했습니다.
2. 홈 화면에 Feedback 모달을 추가했습니다.
 @jinaji 님이 #230 에서 말씀하셨던 #207 이슈를 처리했습니다.

## 참고사항
취소 모달의 Select항목의 추가 아이디어가 안떠올라서 일단 3개만 했는데, 추가적으로 넣으면 좋을 것같다는 의견 있으면 남겨주세요
## ScreenShot
<img width="758" alt="image" src="https://github.com/manito42/FrontEnd/assets/52999093/2c896de6-2994-4d70-b20b-0626587c872d">
<img width="761" alt="image" src="https://github.com/manito42/FrontEnd/assets/52999093/03a3d051-88f6-43d8-b01e-92bfd739e2a5">
