### PR TITLE
[fix]: banner length로 화살표, 하단 동그라미 렌더링 여부 판단

### DIFF
--- a/42manito/src/components/Banners/TopBanner.tsx
+++ b/42manito/src/components/Banners/TopBanner.tsx
@@ -10,6 +10,7 @@ interface props {
 
 // 추후 여러 배너를 받을 수 있는 형태로 수정이 필요함.
 export default function TopBanner({ banner }: props) {
+  const bannerLength = banner.length;
   const router = useRouter();
   const [currentIndex, setCurrentIndex] = useState(0);
   const handleBannerClick = () => {
@@ -72,14 +73,16 @@ export default function TopBanner({ banner }: props) {
       <div
         className={`top-banner-wrapper ${banner[currentIndex].backgroundColor} ${banner[currentIndex].textColor}`}
       >
-        <div className="left-arrow-wrapper">
-          <button
-            className="left-arrow-button"
-            onClick={() => sideButtonHandler("left")}
-          >
-            <CaretLeftOutlined className="left-arrow"></CaretLeftOutlined>
-          </button>
-        </div>
+        {bannerLength !== 1 && (
+          <div className="left-arrow-wrapper">
+            <button
+              className="left-arrow-button"
+              onClick={() => sideButtonHandler("left")}
+            >
+              <CaretLeftOutlined className="left-arrow"></CaretLeftOutlined>
+            </button>
+          </div>
+        )}
         <div className="top-banner-container">
           <div className="top-banner-right" onClick={handleBannerClick}>
             <Image
@@ -100,17 +103,21 @@ export default function TopBanner({ banner }: props) {
             </div>
           </div>
         </div>
-        <div className="banner-circles-wrapper">
-          <div className="banner-circles-container ">{bannerCircle}</div>
-        </div>
-        <div className="right-arrow-wrapper">
-          <button
-            className="right-arrow-button"
-            onClick={() => sideButtonHandler("right")}
-          >
-            <CaretRightOutlined className="right-arrow"></CaretRightOutlined>
-          </button>
-        </div>
+        {bannerLength !== 1 && (
+          <div className="banner-circles-wrapper">
+            <div className="banner-circles-container ">{bannerCircle}</div>
+          </div>
+        )}
+        {bannerLength !== 1 && (
+          <div className="right-arrow-wrapper">
+            <button
+              className="right-arrow-button"
+              onClick={() => sideButtonHandler("right")}
+            >
+              <CaretRightOutlined className="right-arrow"></CaretRightOutlined>
+            </button>
+          </div>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
탑배너 컴포넌트로 들어오는 배너 길이 체크해서 화살표와 하단부 동그라미 렌더링 조건 걸었습니다~
<img width="1432" alt="image" src="https://github.com/manito42/FrontEnd/assets/101309869/d0ee118b-5712-4e59-a4d8-54624755e7c2">
배너 하나일 때 ...

배너 컴포넌트 분리 고민해봤는데 ... 언젠가 멘토링 페이지에도 여러 배너가 필요한 상황이 있지 않을까 싶어서 고냥 냅둬도 되지 않을까 해여 ~!
