### PR TITLE
[fix]: 해시태그 잘림 현상 해소 (#246)

### DIFF
--- a/42manito/src/components/Mentor/Card.tsx
+++ b/42manito/src/components/Mentor/Card.tsx
@@ -24,7 +24,7 @@ const sliceHashtags = (hashtags: HashtagResponseDto[], limit: number) => {
     if (acc + hashtag.name.length > limit) {
       continue;
     }
-    acc += hashtag.name.length + 6; // 최적화된 값임.. 6은 #{} 의 길이
+    acc += hashtag.name.length + 7; // 최적화된 값임.. 6은 #{} 의 길이
     slicedHashtags.push(hashtag);
   }
   return slicedHashtags;
@@ -34,7 +34,7 @@ const MentorCard = ({ data }: props) => {
   const dispatch = useAppDispatch();
   const { nickname, profileImage } = data.user;
   const { shortDescription, hashtags } = data;
-  const slicedHashtags = sliceHashtags(hashtags, 31);
+  const slicedHashtags = sliceHashtags(hashtags, 32);
   const openMentorModal = (data: MentorProfileDto) => {
     dispatch(CurrMentorSlice.actions.deleteMentor());
     dispatch(CurrMentorSlice.actions.setMentor(data));


### PR DESCRIPTION
- 한글의 경우 더 넓은 크기를 차지하여 6 -> 7