### PR TITLE
[fix]: 소셜 링크 모달 스타일 에러 수정

### DIFF
--- a/42manito/src/components/Reservation/modal/SocialLinkModal.tsx
+++ b/42manito/src/components/Reservation/modal/SocialLinkModal.tsx
@@ -54,7 +54,7 @@ export default function SocialLinkModal() {
       >
         <div className="connect-container md:w-full">
           <div className="w-full mt-5 self-center flex-col">
-            <span className="connect-text text-lg font-bold pb-3">
+            <span className="connect-text text-lg font-bold pb-3 flex flex-col">
               <svg
                 width="20"
                 height="20"


### PR DESCRIPTION
## [에러 상황]
사파리 이외의 브라우저는 flex가 제대로 설정 됐었는데, 
사파리만 스타일이 안먹어서 수정했습니다.ㅜㅜ

오늘 사용하다 발견해서 수정합니다...

## [수정 전]
<img width="497" alt="스크린샷 2023-11-24 오후 4 00 52" src="https://github.com/manito42/FrontEnd/assets/97217713/f817eb92-4ff2-4114-8050-73ab5b30a98f">


## [수정 후]
<img width="497" alt="스크린샷 2023-11-24 오후 4 00 59" src="https://github.com/manito42/FrontEnd/assets/97217713/64285e18-7c1f-4cc1-97fc-bc7fd99e07dc">
